### PR TITLE
Generate merged ModelName values

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -13,10 +13,12 @@
     <Grid>
         <Button x:Name="btnGetAircraft" Content="{x:Static properties:Resources.GetAircraftButtonLabel}" HorizontalAlignment="Left" Margin="10,10,0,0" VerticalAlignment="Top" Command="{Binding GetLiveriesCommand}"/>
         <Button x:Name="btnSave" Content="{x:Static properties:Resources.SaveButtonLabel}" HorizontalAlignment="Left" Margin="78,10,0,0" VerticalAlignment="Top" Command="{Binding SaveLiveriesCommand}" RenderTransformOrigin="-0.856,0.538"/>
-        <DataGrid d:ItemsSource="{d:SampleData ItemCount=5}" ItemsSource="{Binding Liveries}" Margin="10,35,10,25" AutoGenerateColumns="False" HeadersVisibility="Column">
+        <DataGrid d:ItemsSource="{d:SampleData ItemCount=5}" ItemsSource="{Binding Liveries}" Margin="10,35,10,25" AutoGenerateColumns="False" CanUserAddRows="False" HeadersVisibility="Column">
             <DataGrid.Columns>
-                <DataGridTextColumn Header="{x:Static properties:Resources.DataGridModelNameHeader}" Binding="{Binding ModelName}"/>
+                <DataGridTextColumn Header="{x:Static properties:Resources.DataGridCallsignPrefixHeader}" Binding="{Binding CallsignPrefix}"/>
+                <DataGridTextColumn Header="{x:Static properties:Resources.DataGridFlightNumberRangeHeader}" Binding="{Binding FlightNumberRange}"/>
                 <DataGridTextColumn Header="{x:Static properties:Resources.DataGridTypeCodeHeader}" Binding="{Binding TypeCode}"/>
+                <DataGridTextColumn Header="{x:Static properties:Resources.DataGridModelNameHeader}" Binding="{Binding ModelName}"/>
             </DataGrid.Columns>
         </DataGrid>
         <StatusBar VerticalAlignment="Bottom">

--- a/Models/Livery.cs
+++ b/Models/Livery.cs
@@ -5,9 +5,17 @@ namespace vmr_generator.Models
     [XmlType("ModelMatchRule")]
     public class Livery
     {
+        [XmlAttribute("CallsignPrefix")]
+        public string CallsignPrefix { get; set; }
+
+
+        [XmlAttribute("FlightNumberRange")]
+        public string FlightNumberRange { get; set; }
+
         [XmlAttribute("TypeCode")]
 
         public string TypeCode { get; set; }
+
         [XmlAttribute("ModelName")]
 
         public string ModelName { get; set; }

--- a/Properties/Resources.Designer.cs
+++ b/Properties/Resources.Designer.cs
@@ -61,6 +61,24 @@ namespace vmr_generator.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Callsign prefix.
+        /// </summary>
+        public static string DataGridCallsignPrefixHeader {
+            get {
+                return ResourceManager.GetString("DataGridCallsignPrefixHeader", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Flight numbers.
+        /// </summary>
+        public static string DataGridFlightNumberRangeHeader {
+            get {
+                return ResourceManager.GetString("DataGridFlightNumberRangeHeader", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Model name.
         /// </summary>
         public static string DataGridModelNameHeader {

--- a/Properties/Resources.resx
+++ b/Properties/Resources.resx
@@ -117,6 +117,14 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="DataGridCallsignPrefixHeader" xml:space="preserve">
+    <value>Callsign prefix</value>
+    <comment>Header for the callsign prefix column in the main window data grid.</comment>
+  </data>
+  <data name="DataGridFlightNumberRangeHeader" xml:space="preserve">
+    <value>Flight numbers</value>
+    <comment>Header for the flight number range column in the main window data grid.</comment>
+  </data>
   <data name="DataGridModelNameHeader" xml:space="preserve">
     <value>Model name</value>
     <comment>Header for the model name column in the main window data grid.</comment>


### PR DESCRIPTION
Fixes #16

Adds support for `CallsignPrefix` and `FlightNumberRange`. Properly groups by `CallsignPrefix`, `TypeCode` and `FlightNumberRange` to generate single model matching entries that merge all the grouped models into a single `ModelName` property separated by double slashes (//).